### PR TITLE
Initial renaming and setup of forked theme

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ achieve these goals?
 #### How can a reviewer manually see the effects of these changes?
 
 #### What are the relevant tickets?
-- https://mitlibraries.atlassian.net/browse/NTI-
+- https://mitlibraries.atlassian.net/browse/WRP-
 
 #### Screenshots (if appropriate)
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ logs
 results
 _notes
 
+package-lock.json
+
 npm-debug.log
 
 .sass-cache
@@ -21,3 +23,4 @@ node_modules/
 
 css/build/**
 js/build/**
+/vendor/

--- a/404.php
+++ b/404.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Creating_an_Error_404_Page
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 get_header(); ?>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![Build Status](https://travis-ci.org/MITLibraries/mitlib-courtyard.svg)](https://travis-ci.org/MITLibraries/mitlib-courtyard)
-[![Code Climate](https://codeclimate.com/github/MITLibraries/mitlib-courtyard/badges/gpa.svg)](https://codeclimate.com/github/MITLibraries/mitlib-courtyard)
+[![Build Status](https://travis-ci.org/MITLibraries/cms1b-courtyard.svg)](https://travis-ci.org/MITLibraries/cms1b-courtyard)
+[![Code Climate](https://codeclimate.com/github/MITLibraries/cms1b-courtyard/badges/gpa.svg)](https://codeclimate.com/github/MITLibraries/cms1b-courtyard)
 
-Mitlib-Courtyard
+CMS1b-Courtyard
 ======
 
-Mitlib-Courtyard is a base WordPress theme for use on internal projects at the MIT Libraries. It has been created by [Matt Bernhardt](https://github.com/matt-bernhardt) from the [\_strap](https://github.com/ptbello/_strap) starter theme.
+CMS1b-Courtyard is a base WordPress theme for use on internal projects at the MIT Libraries. It has been created by [Matt Bernhardt](https://github.com/matt-bernhardt) from the [\_strap](https://github.com/ptbello/_strap) starter theme.
 
 ## A note for developers and contributors:
 

--- a/archive.php
+++ b/archive.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 get_header(); ?>

--- a/comments.php
+++ b/comments.php
@@ -7,7 +7,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 /*

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "matt-bernhardt/cms1b-courtyard",
+    "description": "A WordPress theme that is compatible with Pantheon deploys and CircleCI builds",
+    "type": "wordpress-theme",
+    "license": "GPL3",
+    "authors": [
+        {
+            "name": "Matt Bernhardt",
+            "email": "mjbernha@mit.edu"
+        }
+    ],
+    "require": {}
+}

--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,6 @@
 /*
-Theme Name: MITlib Courtyard
-Theme URI: https://github.com/mitlibraries/mitlib-courtyard
+Theme Name: CMS1b Courtyard
+Theme URI: https://github.com/mitlibraries/cms1b-courtyard
 Author: Matt Bernhardt
 Author URI: http://github.com/matt-bernhardt/
 Description: This is a parent / base theme that is meant as a scaffold for child sites. It is based on _strap.

--- a/footer.php
+++ b/footer.php
@@ -6,7 +6,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 ?>

--- a/functions.php
+++ b/functions.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Mitlib-Courtyard functions and definitions.
+ * cms1b-courtyard functions and definitions.
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 if ( ! function_exists( 'courtyard_setup' ) ) :

--- a/header.php
+++ b/header.php
@@ -6,7 +6,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 ?><!DOCTYPE html>

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -12,7 +12,7 @@
  *
  * @link http://codex.wordpress.org/Custom_Headers
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 /**

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Mitlib-courtyard Theme Customizer.
+ * cms1b-courtyard Theme Customizer.
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 /**

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -4,7 +4,7 @@
  *
  * Eventually, some of the functionality here could be replaced by core features.
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 /**

--- a/inc/functions-strap.php
+++ b/inc/functions-strap.php
@@ -2,7 +2,7 @@
 /**
  * This needs to describe the functions-strap php file.
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 /**

--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -4,7 +4,7 @@
  *
  * @link https://jetpack.me/
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 /**

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -4,7 +4,7 @@
  *
  * Eventually, some of the functionality here could be replaced by core features.
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 if ( ! function_exists( 'courtyard_posted_on' ) ) :

--- a/inc/wpcom.php
+++ b/inc/wpcom.php
@@ -4,7 +4,7 @@
  *
  * This file is centrally included from `wp-content/mu-plugins/wpcom-theme-compat.php`.
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 /**

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 get_header(); ?>

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "mitlib-courtyard",
+  "name": "cms1b-courtyard",
   "version": "1.2.0",
   "description": "Build tooling for the MIT Libraries' 'courtyard' Wordpress theme.",
-  "bugs": "https://github.com/MITLibraries/mitlib-courtyard/issues",
+  "bugs": "https://github.com/MITLibraries/cms1b-courtyard/issues",
   "license": "MIT",
-  "repository" : {
+  "repository": {
     "type": "git",
-    "url": "https://github.com/MITLibraries/mitlib-courtyard"
+    "url": "https://github.com/MITLibraries/cms1b-courtyard"
   },
   "devDependencies": {
     "glob": "~7.1.2",

--- a/page.php
+++ b/page.php
@@ -9,7 +9,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 get_header(); ?>

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -1,5 +1,5 @@
 /*
-Theme Name: mitlib-courtyard
+Theme Name: cms1b-courtyard
 Theme URI:
 Author:
 Author URI:

--- a/search.php
+++ b/search.php
@@ -4,7 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#search-result
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 get_header(); ?>

--- a/searchform.php
+++ b/searchform.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying search forms in Courtyard
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 ?>

--- a/sidebar.php
+++ b/sidebar.php
@@ -4,7 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 if ( ! is_active_sidebar( 'sidebar-1' ) ) {

--- a/single.php
+++ b/single.php
@@ -4,7 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 get_header(); ?>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 /*
-Theme Name: MITlib Courtyard
-Theme URI: https://github.com/mitlibraries/mitlib-courtyard
+Theme Name: CMS1b Courtyard
+Theme URI: https://github.com/mitlibraries/cms1b-courtyard
 Author: Matt Bernhardt
 Author URI: http://github.com/matt-bernhardt/
 Description: This is a parent / base theme that is meant as a scaffold for child sites. It is based on _strap.

--- a/style.less
+++ b/style.less
@@ -1,5 +1,5 @@
 /*
-Theme Name: mitlib-courtyard
+Theme Name: cms1b-courtyard
 Theme URI:
 Author:
 Author URI:

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 ?>

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 ?>

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 ?>

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 ?>

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package mitlib-courtyard
+ * @package cms1b-courtyard
  */
 
 ?>


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This completes the initial fork of this theme from the original [MITlib Courtyard](https://github.com/MITLibraries/mitlib-courtyard) project to this speculative work.

#### Helpful background context (if appropriate)
The long term goal for _this_ project is to enable our WordPress themes to take advantage of a build step on a CI provider, rather than needing our deploy staff to run the deploys interactively on the target server.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/WRP-274

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
YES - the deploy process should no allow Composer-managed site assembly